### PR TITLE
Fix root volume configuration for AWS Terraform deployments

### DIFF
--- a/deployment/aws/cloudformation/controller_proxy_and_agent_pair/README.md
+++ b/deployment/aws/cloudformation/controller_proxy_and_agent_pair/README.md
@@ -64,9 +64,9 @@ After successful deployment of stack, flow bellow instructions
 -	Go to EC2 Dashboard and look for the deployed instance
 -	Select the Controller Proxy instance and check the public IP 
 -	Open your browser and access pre existing CyPerf Controller UI with URL https://"Controller Public IP" (Default Username/Password: `admin`/`CyPerf&Keysight#1`)
--   Select the gear icon in the right top corner. Select “Administration”, followed by Controller Proxies. 
+-   Select the gear icon in the right top corner. Select “Agent Management...”, followed by Controller Proxies. 
     If Controller and Controller Proxy are in same vpc, add the Controller Proxy private IP.
     Else, add Controller Proxy Public IP. Allow Controller Public IP at Controller proxy's inbound Security rule for port 443.
 -   Registered CyPerf agents should appear in Controller UI automatically.
--   CyPerf license needs to be procured for further usage. These licenses need to be configured at “Administration” followed by “License Manager” on CyPerf controller gear menu.
+-   A valid CyPerf license must be procured prior to continued use of the product. To configure licensing, navigate to the CyPerf Controller and go to Settings > Licenses > License Manager. To configure an external License Server, navigate to Settings > Licenses > License Server and provide the required server details.
 

--- a/deployment/aws/terraform/2_vpcs_multiple_ips/main.tf
+++ b/deployment/aws/terraform/2_vpcs_multiple_ips/main.tf
@@ -246,8 +246,6 @@ resource "aws_instance" "mdw" {
     instance_type = var.aws_mdw_machine_type
 
     root_block_device {
-        volume_size           = "100"
-        volume_type           = "gp3"
         delete_on_termination = true
     }
 
@@ -505,8 +503,6 @@ resource "aws_instance" "broker" {
     instance_type = var.aws_broker_machine_type
 
     root_block_device {
-        volume_size           = "30"
-        volume_type           = "gp3"
         delete_on_termination = true
     }
 

--- a/deployment/aws/terraform/2_vpcs_multiple_ips/main.tf
+++ b/deployment/aws/terraform/2_vpcs_multiple_ips/main.tf
@@ -4,6 +4,14 @@ provider "aws" {
   region = var.aws_region
 }
 
+data "aws_ssm_parameter" "cyperf_mdw_ami" {
+  name = "/aws/service/marketplace/prod-svag4bs7dtcbu/${var.cyperf_release}"
+}
+
+data "aws_ssm_parameter" "cyperf_broker_ami" {
+  name = "/aws/service/marketplace/prod-xopwud6rtquaw/${var.cyperf_release}"
+}
+
 locals{
     main_cidr = "172.16.0.0/16"
     main_mgmt_subnet = "172.16.1.0/24"
@@ -234,13 +242,12 @@ resource "aws_instance" "mdw" {
         Name = local.mdw_name
     }
 
-
-    ami           = "resolve:ssm:/aws/service/marketplace/prod-svag4bs7dtcbu/${var.cyperf_release}"
+    ami           = data.aws_ssm_parameter.cyperf_mdw_ami.value
     instance_type = var.aws_mdw_machine_type
 
-    ebs_block_device {
-        device_name = "/dev/sda1"
-        volume_size = "100"
+    root_block_device {
+        volume_size           = "100"
+        volume_type           = "gp3"
         delete_on_termination = true
     }
 
@@ -494,13 +501,12 @@ resource "aws_instance" "broker" {
         Name = local.broker_name
     }
 
-
-    ami           = "resolve:ssm:/aws/service/marketplace/prod-xopwud6rtquaw/${var.cyperf_release}"
+    ami           = data.aws_ssm_parameter.cyperf_broker_ami.value
     instance_type = var.aws_broker_machine_type
 
-    ebs_block_device {
-        device_name = "/dev/sda1"
-        volume_size = "100"
+    root_block_device {
+        volume_size           = "30"
+        volume_type           = "gp3"
         delete_on_termination = true
     }
 

--- a/deployment/aws/terraform/controller_and_agent_pair/main.tf
+++ b/deployment/aws/terraform/controller_and_agent_pair/main.tf
@@ -4,6 +4,10 @@ provider "aws" {
   region     = var.aws_region
 }
 
+data "aws_ssm_parameter" "cyperf_mdw_ami" {
+  name = "/aws/service/marketplace/prod-svag4bs7dtcbu/${var.cyperf_release}"
+}
+
 locals {
   main_cidr          = "172.16.0.0/16"
   mgmt_cidr_ipv4     = "172.16.1.0/24"
@@ -256,12 +260,12 @@ resource "aws_instance" "aws_mdw" {
   }
 
 
-  ami           = "resolve:ssm:/aws/service/marketplace/prod-svag4bs7dtcbu/${var.cyperf_release}"
+  ami           = data.aws_ssm_parameter.cyperf_mdw_ami.value
   instance_type = var.aws_mdw_machine_type
 
-  ebs_block_device {
-    device_name           = "/dev/sda1"
+  root_block_device {
     volume_size           = "100"
+    volume_type           = "gp3"
     delete_on_termination = true
   }
 

--- a/deployment/aws/terraform/controller_and_agent_pair/main.tf
+++ b/deployment/aws/terraform/controller_and_agent_pair/main.tf
@@ -264,8 +264,6 @@ resource "aws_instance" "aws_mdw" {
   instance_type = var.aws_mdw_machine_type
 
   root_block_device {
-    volume_size           = "100"
-    volume_type           = "gp3"
     delete_on_termination = true
   }
 

--- a/deployment/aws/terraform/controller_only/main.tf
+++ b/deployment/aws/terraform/controller_only/main.tf
@@ -4,6 +4,10 @@ provider "aws" {
   region     = var.aws_region
 }
 
+data "aws_ssm_parameter" "cyperf_mdw_ami" {
+  name = "/aws/service/marketplace/prod-svag4bs7dtcbu/${var.cyperf_release}"
+}
+
 locals {
   mdw_name           = "${var.aws_stack_name}-mdw-${var.mdw_version}"
   main_cidr          = "172.16.0.0/16"
@@ -124,11 +128,11 @@ resource "aws_instance" "aws_mdw" {
   }
 
 
-  ami           = "resolve:ssm:/aws/service/marketplace/prod-svag4bs7dtcbu/${var.cyperf_release}"
+  ami           = data.aws_ssm_parameter.cyperf_mdw_ami.value
   instance_type = var.aws_mdw_machine_type
-  ebs_block_device {
-    device_name           = "/dev/sda1"
+  root_block_device {
     volume_size           = "256"
+    volume_type           = "gp3"
     delete_on_termination = true
   }
 

--- a/deployment/aws/terraform/controller_only/main.tf
+++ b/deployment/aws/terraform/controller_only/main.tf
@@ -131,8 +131,6 @@ resource "aws_instance" "aws_mdw" {
   ami           = data.aws_ssm_parameter.cyperf_mdw_ami.value
   instance_type = var.aws_mdw_machine_type
   root_block_device {
-    volume_size           = "256"
-    volume_type           = "gp3"
     delete_on_termination = true
   }
 

--- a/deployment/aws/terraform/controller_proxy_and_agent_pair/main.tf
+++ b/deployment/aws/terraform/controller_proxy_and_agent_pair/main.tf
@@ -4,6 +4,10 @@ provider "aws" {
   region     = var.aws_region
 }
 
+data "aws_ssm_parameter" "cyperf_broker_ami" {
+  name = "/aws/service/marketplace/prod-xopwud6rtquaw/${var.cyperf_release}"
+}
+
 locals {
   main_cidr          = "172.16.0.0/16"
   mgmt_cidr_ipv4     = "172.16.1.0/24"
@@ -254,12 +258,12 @@ resource "aws_instance" "aws_broker" {
   tags = {
     Name = local.broker_name
   }
-  ami           = "resolve:ssm:/aws/service/marketplace/prod-xopwud6rtquaw/${var.cyperf_release}"
+  ami           = data.aws_ssm_parameter.cyperf_broker_ami.value
   instance_type = var.aws_broker_machine_type
 
-  ebs_block_device {
-    device_name           = "/dev/sda1"
-    volume_size           = "100"
+  root_block_device {
+    volume_size           = "30"
+    volume_type           = "gp3"
     delete_on_termination = true
   }
 
@@ -287,6 +291,7 @@ resource "aws_instance" "aws_client_agent" {
     volume_size           = "16"
     delete_on_termination = true
   }
+
 
   network_interface {
     network_interface_id = aws_network_interface.aws_client_mgmt_interface.id

--- a/deployment/aws/terraform/controller_proxy_and_agent_pair/main.tf
+++ b/deployment/aws/terraform/controller_proxy_and_agent_pair/main.tf
@@ -262,8 +262,6 @@ resource "aws_instance" "aws_broker" {
   instance_type = var.aws_broker_machine_type
 
   root_block_device {
-    volume_size           = "30"
-    volume_type           = "gp3"
     delete_on_termination = true
   }
 

--- a/deployment/azure/azureresourcemanager/controller_proxy_and_agent_pair/README.md
+++ b/deployment/azure/azureresourcemanager/controller_proxy_and_agent_pair/README.md
@@ -65,6 +65,6 @@ After successful deployment of stack, flow bellow instructions
 -	Go to Azure console and look for the deployed VMs
 -	Select the Controller Proxy instance and check the public IP 
 -	Open your browser and access preexisting CyPerf Controller UI with URL https://"Controller Public IP" (Default Username/Password: `admin`/`CyPerf&Keysight#1`)
--   Select the gear icon in the right top corner. Select “Administration”, followed by “Controller Proxies” and then add the Controller Proxy public IP.
+-   Select the gear icon in the right top corner. Select "Agent Management...", followed by “Controller Proxies” and then add the Controller Proxy public IP.
 -   Registered CyPerf agents should appear in Controller UI automatically.
--   CyPerf license needs to be procured for further usage. These licenses need to be configured at “Administration” followed by “License Manager” on CyPerf controller gear menu.
+-   A valid CyPerf license must be procured prior to continued use of the product. To configure licensing, navigate to the CyPerf Controller and go to Settings > Licenses > License Manager. To configure an external License Server, navigate to Settings > Licenses > License Server and provide the required server details.

--- a/deployment/gcp/deploymentmanager/controller_proxy_and_agent_pair/README.md
+++ b/deployment/gcp/deploymentmanager/controller_proxy_and_agent_pair/README.md
@@ -106,6 +106,6 @@ After successful deployment of stack, flow bellow instructions
 -	Go to GCP console and look for the deployed VMs
 -	Select the Controller Proxy instance and check the public IP 
 -	Open your browser and access pre existing CyPerf Controller UI with URL https://"Controller Public IP" (Default Username/Password: `admin`/`CyPerf&Keysight#1`)
--   Select the gear icon in the right top corner. Select “Administration”, followed by “Controller Proxies” and then add the Controller Proxy public IP.
+-   Select the gear icon in the right top corner. Select “Agent Management...”, followed by “Controller Proxies” and then add the Controller Proxy public IP.
 -   Registered CyPerf agents should appear in Controller UI automatically.
--   CyPerf license needs to be procured for further usage. These licenses need to be configured at “Administration” followed by “License Manager” on CyPerf controller gear menu.
+-   A valid CyPerf license must be procured prior to continued use of the product. To configure licensing, navigate to the CyPerf Controller and go to Settings > Licenses > License Manager. To configure an external License Server, navigate to Settings > Licenses > License Server and provide the required server details.


### PR DESCRIPTION
All AWS Terraform deployments used ebs_block_device to configure the root disk, which is incorrect — ebs_block_device is for additional volumes. 
Switching to root_block_device exposed a secondary bug: the AWS Terraform provider fails to resolve inline resolve:ssm:... AMI strings when root_block_device is present, causing AWS to reject the deployment with InvalidAMIID.Malformed.

Fix:
- Replaced ebs_block_device with root_block_device and set volume_type = "gp3" across all AWS deployments
- Replaced inline resolve:ssm:... AMI strings with explicit data "aws_ssm_parameter" data sources to work around the broken provider resolution logic
- Corrected broker volume size from 100 GB to 30 GB

This PR also covers updates for some README files to reflect the current CyPerf Controller UI